### PR TITLE
Show relative paths for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ vendor/bin/phpstan analyse src -l8 --error-format blade
 
 ### Known issues / TODOs
 
-- [ ] In error formatter relative paths for templates can be displayed, instead of just file name.
 - [ ] Custom directives are not supported. Can be supported by custom bootstrap file maybe.
 - [ ] Blade components are not analyzed. Support for it will come soon. 
 

--- a/config/extension.neon
+++ b/config/extension.neon
@@ -29,6 +29,9 @@ services:
     - Vural\PHPStanBladeRule\NodeAnalyzer\ViewDataParametersAnalyzer
     - Vural\PHPStanBladeRule\NodeAnalyzer\CompactFunctionCallParameterResolver
     - Vural\PHPStanBladeRule\NodeAnalyzer\ValueResolver
-    - Vural\PHPStanBladeRule\Compiler\FileNameAndLineNumberAddingPreCompiler
+    - 
+        class: Vural\PHPStanBladeRule\Compiler\FileNameAndLineNumberAddingPreCompiler
+        arguments:
+            templatePaths: %templatePaths%
     - Vural\PHPStanBladeRule\Compiler\BladeToPHPCompiler
     - Vural\PHPStanBladeRule\PHPParser\NodeVisitor\BladeLineNumberNodeVisitor

--- a/src/Compiler/BladeToPHPCompiler.php
+++ b/src/Compiler/BladeToPHPCompiler.php
@@ -96,7 +96,7 @@ final class BladeToPHPCompiler
         $fileContent = $this->fileSystem->get($filePath);
 
         // TODO: extract class
-        $fileContent = $this->preCompiler->setFileName($this->fileSystem->basename($filePath))->compileString($fileContent);
+        $fileContent = $this->preCompiler->setFileName($filePath)->compileString($fileContent);
 
         $rawPhpContent = $this->compileAndGetStrippedPHP($fileContent);
 
@@ -108,7 +108,7 @@ final class BladeToPHPCompiler
                     $includedFilePath = $this->fileViewFinder->find($include);
                     $fileContents     = $this->fileSystem->get($includedFilePath);
 
-                    $preCompiledContents = $this->preCompiler->setFileName($this->fileSystem->basename($includedFilePath))->compileString($fileContents);
+                    $preCompiledContents = $this->preCompiler->setFileName($includedFilePath)->compileString($fileContents);
                     $includedContent     = $this->compileAndGetStrippedPHP(
                         $preCompiledContents,
                         false

--- a/src/Compiler/FileNameAndLineNumberAddingPreCompiler.php
+++ b/src/Compiler/FileNameAndLineNumberAddingPreCompiler.php
@@ -4,15 +4,27 @@ declare(strict_types=1);
 
 namespace Vural\PHPStanBladeRule\Compiler;
 
+use Illuminate\Support\Str;
+
 use function explode;
 use function implode;
+use function rtrim;
 use function sprintf;
+use function str_contains;
 
 use const PHP_EOL;
 
 final class FileNameAndLineNumberAddingPreCompiler
 {
     private string $fileName;
+
+    /**
+     * @param string[] $templatePaths
+     */
+    public function __construct(
+        private array $templatePaths = [],
+    ) {
+    }
 
     public function compileString(string $value): string
     {
@@ -31,6 +43,15 @@ final class FileNameAndLineNumberAddingPreCompiler
 
     public function setFileName(string $fileName): self
     {
+        foreach ($this->templatePaths as $templatePath) {
+            $templatePath = rtrim($templatePath, '/') . '/';
+
+            if (str_contains($fileName, $templatePath)) {
+                $fileName = Str::after($fileName, $templatePath);
+                break;
+            }
+        }
+
         $this->fileName = $fileName;
 
         return $this;

--- a/tests/Compiler/config/configWithTemplatePaths.neon
+++ b/tests/Compiler/config/configWithTemplatePaths.neon
@@ -1,0 +1,5 @@
+includes:
+    - ../../tests.neon
+parameters:
+    templatePaths:
+        - resources/views


### PR DESCRIPTION
Questions:

- Do you think we need the `$fileSystem->basename()` call anymore?
- Do you think we could reach the end of the `setFileName` function without breaking the loop? (a template that does not contains any of the templatesPaths). If it's not the case we could return instead of breaking.
- Is it possible to match multiple templatesPaths? Maybe… Is it important? Not sure :-)
- Is it possible to fetch the Blade name of the view?

TODO:

- Sort templatePaths by length to match the longer ones first
- If there is multiple templatesPaths, maybe store in the comment the templatePath and then show the full directory to avoid conflicts with same template name in different template paths. Showing the Blade name of the view should fix this.


PS: I was working on the same idea yesterday and you did an awesome job! Looking forward to fix some issues I have with my big 60k Laravel application :-) Since I configured PHPStan, most of the bugs are in templates because they're not checked :-(