### PR TITLE
Add Fixture testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-latest",
         "orchestra/testbench": "^6.24",
-        "doctrine/coding-standard": "^9.0"
+        "doctrine/coding-standard": "^9.0",
+        "symplify/easy-testing": "^10.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -14,6 +14,7 @@
     <file>tests</file>
 
     <exclude-pattern>tests/Rules/templates/*</exclude-pattern>
+    <exclude-pattern>tests/**/Fixture</exclude-pattern>
 
     <!-- Include full Doctrine Coding Standard -->
     <rule ref="Doctrine">

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,6 +21,11 @@ parameters:
 			path: src/Rules/ViewRuleHelper.php
 
 		-
+			message: "#^Parameter \\#1 \\$string of function trim expects string, mixed given\\.$#"
+			count: 1
+			path: tests/Compiler/FileNameAndLineNumberAddingPreCompilerTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$rules of class Vural\\\\PHPStanBladeRule\\\\Rules\\\\BladeRule constructor expects array\\<PHPStan\\\\Rules\\\\Rule\\<PhpParser\\\\Node\\>\\>, array\\{PHPStan\\\\Rules\\\\Operators\\\\InvalidBinaryOperationRule\\} given\\.$#"
 			count: 1
 			path: tests/Rules/BladeViewRuleTest.php

--- a/tests/Compiler/Fixture/multiline_template.blade.php
+++ b/tests/Compiler/Fixture/multiline_template.blade.php
@@ -1,0 +1,7 @@
+<h1>
+    {{ $foo }}
+</h1>
+-----
+/** file: foo.blade.php, line: 1 */<h1>
+/** file: foo.blade.php, line: 2 */    {{ $foo }}
+/** file: foo.blade.php, line: 3 */</h1>

--- a/tests/Compiler/Fixture/single_line_template.blade.php
+++ b/tests/Compiler/Fixture/single_line_template.blade.php
@@ -1,0 +1,3 @@
+{{ $foo }}
+-----
+/** file: foo.blade.php, line: 1 */{{ $foo }}


### PR DESCRIPTION
This PR adds ability to have fixture tests using https://github.com/symplify/easy-testing. It allows us to write tests with 
```
<input>
-----
<expected>
```
format.