### PR TITLE
@include with variable renaming

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -35,4 +35,5 @@ services:
             templatePaths: %templatePaths%
     - Vural\PHPStanBladeRule\Compiler\BladeToPHPCompiler
     - Vural\PHPStanBladeRule\Compiler\PhpContentExtractor
+    - Vural\PHPStanBladeRule\Compiler\IncludeCompiler
     - Vural\PHPStanBladeRule\PHPParser\NodeVisitor\BladeLineNumberNodeVisitor

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -41,7 +41,7 @@ parameters:
 			path: tests/Rules/BladeViewRuleTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$rules of class Vural\\\\PHPStanBladeRule\\\\Rules\\\\BladeRule constructor expects array\\<PHPStan\\\\Rules\\\\Rule\\<PhpParser\\\\Node\\>\\>, array\\{PHPStan\\\\Rules\\\\Operators\\\\InvalidBinaryOperationRule, PHPStan\\\\Rules\\\\Cast\\\\EchoRule\\} given\\.$#"
+			message: "#^Parameter \\#1 \\$rules of class Vural\\\\PHPStanBladeRule\\\\Rules\\\\BladeRule constructor expects array\\<PHPStan\\\\Rules\\\\Rule\\<PhpParser\\\\Node\\>\\>, array\\{PHPStan\\\\Rules\\\\Operators\\\\InvalidBinaryOperationRule, PHPStan\\\\Rules\\\\Cast\\\\EchoRule, PHPStan\\\\Rules\\\\Variables\\\\DefinedVariableRule\\} given\\.$#"
 			count: 1
 			path: tests/Rules/LaravelViewFunctionRuleTest.php
 

--- a/src/Compiler/IncludeCompiler.php
+++ b/src/Compiler/IncludeCompiler.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vural\PHPStanBladeRule\Compiler;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\View\Compilers\BladeCompiler;
+use Illuminate\View\FileViewFinder;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+use PhpParser\PrettyPrinter\Standard;
+use Throwable;
+use Vural\PHPStanBladeRule\ValueObject\BladeInclude;
+
+use function count;
+use function implode;
+use function rtrim;
+use function sprintf;
+use function ucfirst;
+
+use const PHP_EOL;
+
+final class IncludeCompiler
+{
+    private Parser $parser;
+
+    public function __construct(
+        private BladeCompiler $compiler,
+        private Standard $printerStandard,
+        private FileViewFinder $fileViewFinder,
+        private Filesystem $fileSystem,
+        private FileNameAndLineNumberAddingPreCompiler $preCompiler,
+        private PhpContentExtractor $phpContentExtractor,
+    ) {
+        $parserFactory = new ParserFactory();
+        $this->parser  = $parserFactory->create(ParserFactory::PREFER_PHP7);
+    }
+
+    public function decorateInclude(BladeInclude $include): string
+    {
+        try {
+            $includedFilePath     = $this->fileViewFinder->find($include->name);
+            $includedFileContents = $this->fileSystem->get($includedFilePath);
+
+            $preCompiledContents = $this->preCompiler->setFileName($includedFilePath)->compileString($includedFileContents);
+            $compiledContent     = $this->compiler->compileString($preCompiledContents);
+            $includedContent     = $this->phpContentExtractor->extract(
+                $compiledContent,
+                false
+            );
+
+            if (! $include->variables) {
+                return $includedContent;
+            }
+
+            $expressions = $this->parser->parse('<?php ' . rtrim($include->variables, ',') . ';');
+
+            if (! $expressions || count($expressions) !== 1) {
+                return '';
+            }
+
+            if (! ($expressions[0] instanceof Expression)) {
+                return '';
+            }
+
+            $array = $expressions[0]->expr;
+            if (! ($array instanceof Array_)) {
+                return '';
+            }
+
+            $variables = $array->items;
+
+            $variablesDefinitions = [];
+            $variablesReseting    = [];
+            foreach ($variables as $arrayItem) {
+                if (! $arrayItem) {
+                    continue;
+                }
+
+                if (! ($arrayItem->key instanceof String_)) {
+                    continue;
+                }
+
+                $variableName          = $arrayItem->key->value;
+                $temporaryVariableName = '__previous' . ucfirst($variableName);
+                $phpExpression         = $this->printerStandard->prettyPrintExpr($arrayItem->value);
+
+                $variablesDefinitions[] = sprintf('if (isset($%s)) { $%s = $%s; }', $variableName, $temporaryVariableName, $variableName);
+                $variablesDefinitions[] = sprintf('$%s = %s;', $variableName, $phpExpression);
+
+                $variablesReseting[] = sprintf('if (isset($%s)) { $%s = $%s; }', $temporaryVariableName, $variableName, $temporaryVariableName);
+            }
+
+            return implode(PHP_EOL, $variablesDefinitions) . PHP_EOL . $includedContent . PHP_EOL . implode(PHP_EOL, $variablesReseting);
+        } catch (Throwable) {
+            return '';
+        }
+    }
+}

--- a/src/Compiler/IncludeCompiler.php
+++ b/src/Compiler/IncludeCompiler.php
@@ -92,7 +92,7 @@ final class IncludeCompiler
                 $variablesDefinitions[] = sprintf('if (isset($%s)) { $%s = $%s; }', $variableName, $temporaryVariableName, $variableName);
                 $variablesDefinitions[] = sprintf('$%s = %s;', $variableName, $phpExpression);
 
-                $variablesReseting[] = sprintf('if (isset($%s)) { $%s = $%s; }', $temporaryVariableName, $variableName, $temporaryVariableName);
+                $variablesReseting[] = sprintf('if (isset($%s)) { $%s = $%s; } else { unset($%s); }', $temporaryVariableName, $variableName, $temporaryVariableName, $variableName);
             }
 
             return implode(PHP_EOL, $variablesDefinitions) . PHP_EOL . $includedContent . PHP_EOL . implode(PHP_EOL, $variablesReseting);

--- a/src/ValueObject/BladeInclude.php
+++ b/src/ValueObject/BladeInclude.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vural\PHPStanBladeRule\ValueObject;
+
+final class BladeInclude
+{
+    public function __construct(
+        public string $name,
+        public string $variables,
+    ) {
+    }
+}

--- a/tests/Compiler/BladeToPHPCompilerTest.php
+++ b/tests/Compiler/BladeToPHPCompilerTest.php
@@ -19,6 +19,7 @@ use Symplify\TemplatePHPStanCompiler\ValueObject\VariableAndType;
 use Vural\PHPStanBladeRule\Blade\PhpLineToTemplateLineResolver;
 use Vural\PHPStanBladeRule\Compiler\BladeToPHPCompiler;
 use Vural\PHPStanBladeRule\Compiler\FileNameAndLineNumberAddingPreCompiler;
+use Vural\PHPStanBladeRule\Compiler\IncludeCompiler;
 use Vural\PHPStanBladeRule\Compiler\PhpContentExtractor;
 use Vural\PHPStanBladeRule\PHPParser\NodeVisitor\BladeLineNumberNodeVisitor;
 
@@ -39,15 +40,24 @@ class BladeToPHPCompilerTest extends TestCase
 
         $templatePaths = [__DIR__ . '/Fixture/BladeToPHPCompiler'];
 
+        $fileSystem = new Filesystem();
+
         $this->compiler = new BladeToPHPCompiler(
-            $fileSystem = new Filesystem(),
+            new IncludeCompiler(
+                new BladeCompiler($fileSystem, sys_get_temp_dir()),
+                new Standard(),
+                new FileViewFinder($fileSystem, $templatePaths),
+                $fileSystem,
+                new FileNameAndLineNumberAddingPreCompiler($templatePaths),
+                new PhpContentExtractor(),
+            ),
             new BladeCompiler($fileSystem, sys_get_temp_dir()),
             new Standard(),
             new VarDocNodeFactory(),
             new FileViewFinder($fileSystem, $templatePaths),
             new FileNameAndLineNumberAddingPreCompiler($templatePaths),
             new PhpLineToTemplateLineResolver(new BladeLineNumberNodeVisitor()),
-            new PhpContentExtractor()
+            new PhpContentExtractor(),
         );
 
         // Setup the variable names and types that'll be available to all templates

--- a/tests/Rules/LaravelViewFunctionRuleTest.php
+++ b/tests/Rules/LaravelViewFunctionRuleTest.php
@@ -6,8 +6,8 @@ namespace Vural\PHPStanBladeRule\Tests\Rules;
 
 use PHPStan\Rules\Cast\EchoRule;
 use PHPStan\Rules\Operators\InvalidBinaryOperationRule;
-use PHPStan\Rules\Variables\DefinedVariableRule;
 use PHPStan\Rules\Rule;
+use PHPStan\Rules\Variables\DefinedVariableRule;
 use PHPStan\Testing\RuleTestCase;
 use Symplify\TemplatePHPStanCompiler\PHPStan\FileAnalyserProvider;
 use Symplify\TemplatePHPStanCompiler\TypeAnalyzer\TemplateVariableTypesResolver;

--- a/tests/Rules/LaravelViewFunctionRuleTest.php
+++ b/tests/Rules/LaravelViewFunctionRuleTest.php
@@ -6,6 +6,7 @@ namespace Vural\PHPStanBladeRule\Tests\Rules;
 
 use PHPStan\Rules\Cast\EchoRule;
 use PHPStan\Rules\Operators\InvalidBinaryOperationRule;
+use PHPStan\Rules\Variables\DefinedVariableRule;
 use PHPStan\Rules\Rule;
 use PHPStan\Testing\RuleTestCase;
 use Symplify\TemplatePHPStanCompiler\PHPStan\FileAnalyserProvider;
@@ -30,6 +31,7 @@ class LaravelViewFunctionRuleTest extends RuleTestCase
             [
                 self::getContainer()->getByType(InvalidBinaryOperationRule::class),
                 self::getContainer()->getByType(EchoRule::class),
+                self::getContainer()->getByType(DefinedVariableRule::class),
             ],
             self::getContainer()->getByType(BladeViewMethodsMatcher::class),
             self::getContainer()->getByType(LaravelViewFunctionMatcher::class),
@@ -56,6 +58,10 @@ class LaravelViewFunctionRuleTest extends RuleTestCase
             [
                 'Binary operation "+" between string and 10 results in an error.',
                 11,
+            ],
+            [
+                'Binary operation "+" between string and \'bar\' results in an error.',
+                13,
             ],
         ]);
     }

--- a/tests/Rules/LaravelViewFunctionRuleTest.php
+++ b/tests/Rules/LaravelViewFunctionRuleTest.php
@@ -63,6 +63,10 @@ class LaravelViewFunctionRuleTest extends RuleTestCase
                 'Binary operation "+" between string and \'bar\' results in an error.',
                 13,
             ],
+            [
+                'Variable $foo might not be defined.',
+                13,
+            ],
         ]);
     }
 

--- a/tests/Rules/data/laravel-view-function.php
+++ b/tests/Rules/data/laravel-view-function.php
@@ -9,3 +9,5 @@ use function view;
 view('foo', ['foo' => 'bar']);
 
 view('php_directive_with_comment', []);
+
+view('include_with_variable_renaming', ['bar' => 'bar']);

--- a/tests/Rules/templates/include_with_variable_renaming.blade.php
+++ b/tests/Rules/templates/include_with_variable_renaming.blade.php
@@ -1,1 +1,3 @@
 @include('bar', ['foo' => $bar])
+
+{{ $foo }}

--- a/tests/Rules/templates/include_with_variable_renaming.blade.php
+++ b/tests/Rules/templates/include_with_variable_renaming.blade.php
@@ -1,0 +1,1 @@
+@include('bar', ['foo' => $bar])


### PR DESCRIPTION
@include is not working when we pass a second argument with an array of variables.

I will try to code something to fix this.

I added the `DefinedVariableRule` rule to have a better error (`$foo` might not be defined instead of the real error `string + 10` is not possible)