### PR TITLE
Laravel bootstrap

### DIFF
--- a/config/extension.neon
+++ b/config/extension.neon
@@ -1,7 +1,9 @@
 parameters:
     templatePaths: []
+    bootstrapPath: './boostrap/app.php'
 parametersSchema:
     templatePaths: listOf(string())
+    bootstrapPath: string()
 services:
     errorFormatter.blade:
         class: Vural\PHPStanBladeRule\ErrorReporting\PHPStan\ErrorFormatter\BladeTemplateErrorFormatter
@@ -20,6 +22,7 @@ services:
             files: Illuminate\Filesystem\Filesystem()
             paths: %templatePaths%
             extensions: ['blade.php', 'svg']
+    - Vural\PHPStanBladeRule\Laravel\LaravelContainer
     - Vural\PHPStanBladeRule\Rules\ViewRuleHelper
     - Vural\PHPStanBladeRule\Blade\PhpLineToTemplateLineResolver
     - Vural\PHPStanBladeRule\ErrorReporting\Blade\TemplateErrorsFactory

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,6 +6,11 @@ parameters:
 			path: src/Compiler/BladeToPHPCompiler.php
 
 		-
+			message: "#^Cannot call method getFinder\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Laravel/LaravelContainer.php
+
+		-
 			message: "#^Creating new PHPStan\\\\Rules\\\\Registry is not covered by backward compatibility promise\\. The class might change in a minor PHPStan version\\.$#"
 			count: 1
 			path: src/Rules/BladeRule.php

--- a/src/Laravel/LaravelContainer.php
+++ b/src/Laravel/LaravelContainer.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Vural\PHPStanBladeRule\Laravel;
+
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Foundation\Application;
+use Illuminate\View\FileViewFinder;
+use Illuminate\View\ViewFinderInterface;
+use PHPStan\DependencyInjection\Container;
+use PHPStan\File\FileHelper;
+
+use function file_exists;
+
+final class LaravelContainer
+{
+    private ?Application $laravelContainer = null;
+
+    public function __construct(
+        FileHelper $fileHelper,
+        private Container $container,
+    ) {
+        // TODO add parameter in config to change this path
+        $bootstrapPath = $fileHelper->absolutizePath('./bootstrap/app.php');
+
+        if (! file_exists($bootstrapPath)) {
+            return;
+        }
+
+        $this->laravelContainer = require $bootstrapPath;
+
+        $this->laravelContainer->make(Kernel::class)->bootstrap();
+    }
+
+    public function viewFinder(): ViewFinderInterface
+    {
+        if ($this->laravelContainer) {
+            return $this->laravelContainer->make(Factory::class)->getFinder();
+        }
+
+        return $this->container->getByType(FileViewFinder::class);
+    }
+}

--- a/src/NodeAnalyzer/TemplateFilePathResolver.php
+++ b/src/NodeAnalyzer/TemplateFilePathResolver.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Vural\PHPStanBladeRule\NodeAnalyzer;
 
-use Illuminate\View\FileViewFinder;
+use Illuminate\View\ViewFinderInterface;
 use Illuminate\View\ViewName;
 use InvalidArgumentException;
 use PhpParser\Node\Expr;
 use PHPStan\Analyser\Scope;
+use Vural\PHPStanBladeRule\Laravel\LaravelContainer;
 
 use function file_exists;
 use function is_string;
@@ -16,10 +17,13 @@ use function is_string;
 /** @see \Symplify\TemplatePHPStanCompiler\NodeAnalyzer\TemplateFilePathResolver */
 final class TemplateFilePathResolver
 {
+    private ViewFinderInterface $viewFinder;
+
     public function __construct(
-        private FileViewFinder $fileViewFinder,
+        LaravelContainer $laravelContainer,
         private ValueResolver $valueResolver,
     ) {
+        $this->viewFinder = $laravelContainer->viewFinder();
     }
 
     /** @return string[] */
@@ -32,7 +36,6 @@ final class TemplateFilePathResolver
         }
 
         $resolvedValue = $this->normalizeName($resolvedValue);
-
         if (file_exists($resolvedValue)) {
             return [$resolvedValue];
         }
@@ -54,7 +57,7 @@ final class TemplateFilePathResolver
     private function findView(string $view): ?string
     {
         try {
-            return $this->fileViewFinder->find($view);
+            return $this->viewFinder->find($view);
         } catch (InvalidArgumentException) {
             return null;
         }


### PR DESCRIPTION
Right now, the extension doesn't support loading Laravel ServiceProvider for features like:
- Views namespace https://laravel.com/docs/8.x/packages#views (DDD type of application with views in different folders for each domains)
- Custom directives
- Components?

This PR add support to bootstrap the Laravel container and fetch object from Laravel instead of PHPStan. The objects will be fully registered with all custom stuff inside them (view namespaces, custom directives…).

Right now, I just tried to support custom view namespaces (it's working on my application, the extension is now loading all my views). It's really easy to add support for Blade directive too I think (juste swap the PHPStan container for the BladeCompiler for the configured Laravel one).

I put a fallback to the PHPStan container because for the tests with don't have access to Laravel (the bootstrap file doesn't exists). If we continue down this path (and I think we should load Laravel to allow for complete checks), we need to find a way to test these features (maybe [Orchestral/testbench](https://github.com/orchestral/testbench) but not sure if it's working for a PHPStan extension…). Or a fully laravel/laravel application inside a subfolder?

I'm not sure that the `templatesPaths` parameter is require if we have the bootstrap file because all information is present inside `config/view.php` and since Laravel is fully loaded, the config is loaded too.

For the loading part, I was inspired by the `CreatesApplication` trait for testing inside laravel/laravel https://github.com/laravel/laravel/blob/8.x/tests/CreatesApplication.php