### PR TITLE
Using PHP inside HTML attributes is not working

### DIFF
--- a/tests/Compiler/Fixture/PhpContentExtractor/echo_inside_html_tag.blade.php
+++ b/tests/Compiler/Fixture/PhpContentExtractor/echo_inside_html_tag.blade.php
@@ -1,0 +1,4 @@
+<div class="{{ $foo }}"></div>
+-----
+<?php
+/** file: foo.blade.php, line: 1 */ echo e($foo);


### PR DESCRIPTION
Hi,

A small bug I discovered, when using PHP inside HTML attributes the `removeHtmlTags` is not doing something correct… Not sure how to fix it.