### PR TITLE
feat: add support for array-based `with()` calls

### DIFF
--- a/src/NodeAnalyzer/MagicViewWithCallParameterResolver.php
+++ b/src/NodeAnalyzer/MagicViewWithCallParameterResolver.php
@@ -35,7 +35,14 @@ final class MagicViewWithCallParameterResolver
 
             if ($methodName !== null) {
                 if ($methodName === 'with') {
-                    $result[] = new Node\Expr\ArrayItem($parent->getArgs()[1]->value, $parent->getArgs()[0]->value);
+                    if (($arguments = $parent->getArgs()[0]->value) instanceof Node\Expr\Array_) {
+                        /** @var Node\Expr\ArrayItem $value */
+                        foreach ($arguments->items as $value) {
+                            $result[] = new Node\Expr\ArrayItem($value->value, $value->key);
+                        }
+                    } else {
+                        $result[] = new Node\Expr\ArrayItem($parent->getArgs()[1]->value, $parent->getArgs()[0]->value);
+                    }
                 } elseif (str_starts_with($methodName, 'with')) {
                     $result[] = new Node\Expr\ArrayItem($parent->getArgs()[0]->value, new Node\Scalar\String_(Str::camel(substr($methodName, 4))));
                 }

--- a/src/NodeAnalyzer/MagicViewWithCallParameterResolver.php
+++ b/src/NodeAnalyzer/MagicViewWithCallParameterResolver.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Str;
 use PhpParser\Node;
 use Symplify\Astral\Naming\SimpleNameResolver;
 
+use function assert;
 use function str_starts_with;
 use function substr;
 
@@ -36,7 +37,7 @@ final class MagicViewWithCallParameterResolver
             if ($methodName !== null) {
                 if ($methodName === 'with') {
                     if (($arguments = $parent->getArgs()[0]->value) instanceof Node\Expr\Array_) {
-                        /** @var Node\Expr\ArrayItem $value */
+                        assert($value instanceof Node\Expr\ArrayItem);
                         foreach ($arguments->items as $value) {
                             $result[] = new Node\Expr\ArrayItem($value->value, $value->key);
                         }

--- a/tests/Rules/LaravelViewFunctionRuleTest.php
+++ b/tests/Rules/LaravelViewFunctionRuleTest.php
@@ -107,6 +107,10 @@ class LaravelViewFunctionRuleTest extends RuleTestCase
                 'Undefined variable: $bar',
                 22,
             ],
+            [
+                'Binary operation "+" between string and \'bar\' results in an error.',
+                24,
+            ],
         ]);
     }
 

--- a/tests/Rules/data/laravel-view-function.php
+++ b/tests/Rules/data/laravel-view-function.php
@@ -21,4 +21,4 @@ view('file_with_include', ['foo' => 'foo']);
 
 view('file_with_recursive_include', ['foo' => 'foo']);
 
-view('foo')->with(['foo' => 'bar']);
+view('bar')->with(['foo' => 'bar']);

--- a/tests/Rules/data/laravel-view-function.php
+++ b/tests/Rules/data/laravel-view-function.php
@@ -20,3 +20,5 @@ view('simple_variable')->with('foo', 'bar');
 view('file_with_include', ['foo' => 'foo']);
 
 view('file_with_recursive_include', ['foo' => 'foo']);
+
+view('foo')->with(['foo' => 'foo']);

--- a/tests/Rules/data/laravel-view-function.php
+++ b/tests/Rules/data/laravel-view-function.php
@@ -21,4 +21,4 @@ view('file_with_include', ['foo' => 'foo']);
 
 view('file_with_recursive_include', ['foo' => 'foo']);
 
-view('foo')->with(['foo' => 'foo']);
+view('foo')->with(['foo' => 'bar']);


### PR DESCRIPTION
This allows for the usage of `view('abc')->with(['a' => true, 'b' => false]);` which currently throws an `Internal error` (as shown below).

```txt
Internal error: Internal error:
     PhpParser\Node\Expr\ArrayItem::__construct(): Argument #1 ($value) must
     be of type PhpParser\Node\Expr, null given, called in
     /Users/owen.voke/work/platform/vendor/canvural/phpstan-blade-rule/src/Nod
     eAnalyzer/MagicViewWithCallParameterResolver.php on line 38
```

I'm not actually sure how many people use this over `view('name', [/* ... */])` but noticed this was causing issues when trying to use this package in one of our projects. I guess we could easily refactor to not use array-based `with()` too.