### PR TITLE
Update laravel and phpstan package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,16 +4,16 @@
     "type": "phpstan-extension",
     "require": {
         "php": "^8.0",
-        "phpstan/phpstan": "^1.4.6",
-        "illuminate/view": "^8.82 || ^9",
+        "phpstan/phpstan": "^1.8.9",
+        "illuminate/view": "^8.82 || ^9.0 || ^10.0",
         "symplify/template-phpstan-compiler": "^10.0.20",
-        "illuminate/filesystem": "^8.82 || ^9.0",
-        "illuminate/contracts": "^8.82 || ^9.0"
+        "illuminate/filesystem": "^8.82 || ^9.0 || ^10.0",
+        "illuminate/contracts": "^8.82 || ^9.0 || ^10.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
         "roave/security-advisories": "dev-latest",
-        "orchestra/testbench": "^6.24 || ^7.0",
+        "orchestra/testbench": "^6.24 || ^7.0 || ^8.0",
         "doctrine/coding-standard": "^9.0",
         "symplify/easy-testing": "^10.0"
     },

--- a/src/Rules/BladeRule.php
+++ b/src/Rules/BladeRule.php
@@ -6,7 +6,7 @@ namespace Vural\PHPStanBladeRule\Rules;
 
 use PhpParser\Node;
 use PHPStan\Analyser\Scope;
-use PHPStan\Rules\Registry;
+use PHPStan\Rules\DirectRegistry;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use Vural\PHPStanBladeRule\NodeAnalyzer\BladeViewMethodsMatcher;
@@ -25,7 +25,7 @@ class BladeRule implements Rule
         private LaravelViewFunctionMatcher $laravelViewFunctionMatcher,
         private ViewRuleHelper $ruleHelper
     ) {
-        $this->ruleHelper->setRegistry(new Registry($rules));
+        $this->ruleHelper->setRegistry(new DirectRegistry($rules));
     }
 
     public function getNodeType(): string

--- a/src/Rules/ViewRuleHelper.php
+++ b/src/Rules/ViewRuleHelper.php
@@ -91,7 +91,7 @@ final class ViewRuleHelper
 
         $fileAnalyser = $this->fileAnalyserProvider->provide();
 
-        $fileAnalyserResult = $fileAnalyser->analyseFile($tmpFilePath, [], $this->registry, null);
+        $fileAnalyserResult = $fileAnalyser->analyseFile($tmpFilePath, [], $this->registry, /* TODO set collector registry */, null);
 
         $ruleErrors = $fileAnalyserResult->getErrors();
 


### PR DESCRIPTION
Current `main` is incompatible and errors with:

<img width="1062" alt="Bildschirmfoto 2023-02-15 um 23 58 38" src="https://user-images.githubusercontent.com/1698337/219212411-d267999b-a8c3-4751-8ad9-1ce5e3a82689.png">


This branch is baded on v0.4 but still some errors appear which I'm not sure how to fix.
